### PR TITLE
Fix extraFiles configuration and improve unit tests

### DIFF
--- a/charts/init-vault/Chart.yaml
+++ b/charts/init-vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: init-vault
-version: 0.1.0
+version: 0.1.1
 description: A Helm chart that launches a job to init vault.
 
 maintainers:

--- a/charts/init-vault/templates/job.yaml
+++ b/charts/init-vault/templates/job.yaml
@@ -121,10 +121,10 @@ spec:
           secretName: {{ .Values.extraFiles.existingSecret }}
         {{- else if .Values.extraFiles.configMap }}
         configMap:
-          name: {{ .Values.extraFiles.configMap }}
+          name: {{ .Values.extraFiles.configMap.name }}
         {{- else if .Values.extraFiles.secret }}
         secret:
-          secretName: {{ .Values.extraFiles.secret }}
+          secretName: {{ .Values.extraFiles.secret.name }}
         {{- else if .Values.extraFiles.existingVolume }}
         persistentVolumeClaim:
           claimName: {{ .Values.extraFiles.existingVolume }}

--- a/charts/init-vault/tests/extra_files_configmap_test.yaml
+++ b/charts/init-vault/tests/extra_files_configmap_test.yaml
@@ -8,7 +8,7 @@ tests:
   - it: should mount extraFiles configMap as volume
     set:
       extraFiles.enabled: true
-      extraFiles.configMap: test-files-cm
+      extraFiles.configMap.name: test-files-cm
       extraFiles.mountPath: /extra-files
       extraFiles.readOnly: true
     asserts:

--- a/charts/init-vault/tests/extra_files_volume_names_test.yaml
+++ b/charts/init-vault/tests/extra_files_volume_names_test.yaml
@@ -1,0 +1,28 @@
+suite: extraFiles volume names
+
+templates:
+  - templates/job.yaml
+
+# This test ensures that the extraFiles secret and configMap names are read and rendered correctly in the Job volumes
+
+tests:
+  - it: should use the correct extraFiles secret name
+    values:
+      - values/extra-files-secret.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-files
+            secret:
+              secretName: my-extra-secret
+  - it: should use the correct extraFiles configMap name
+    values:
+      - values/extra-files-configmap.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-files
+            configMap:
+              name: my-extra-configmap

--- a/charts/init-vault/tests/values/extra-files-configmap.yaml
+++ b/charts/init-vault/tests/values/extra-files-configmap.yaml
@@ -1,6 +1,7 @@
 # values for testing extraFiles with a configMap
 extraFiles:
   enabled: true
-  configMap: test-files-cm
+  configMap:
+    name: my-extra-configmap
   mountPath: /extra-files
   readOnly: true

--- a/charts/init-vault/tests/values/extra-files-secret.yaml
+++ b/charts/init-vault/tests/values/extra-files-secret.yaml
@@ -1,0 +1,6 @@
+extraFiles:
+  enabled: true
+  secret:
+    name: my-extra-secret
+  mountPath: /extra-files
+  readOnly: true


### PR DESCRIPTION
Correct the handling of extraFiles in the configMap and secret, ensuring proper name references. Update unit tests to validate these changes.